### PR TITLE
hint/proposal for fixing a view locating issue

### DIFF
--- a/sample/WebApplication/Features/Bar/Home.cshtml
+++ b/sample/WebApplication/Features/Bar/Home.cshtml
@@ -1,0 +1,3 @@
+﻿<div>
+    Main content rendered by FEATURE:Bar:HomeController::Home
+</div>

--- a/sample/WebApplication/Features/Bar/HomeController.cs
+++ b/sample/WebApplication/Features/Bar/HomeController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApplication.Features.Bar
+{
+    [Route("Bar/[controller]")]
+    public class HomeController : Controller
+    {
+        public IActionResult Home()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult Search()
+        {
+            // do some stuff...
+            return View("Home");            
+            // this will also work
+            // return Redirect("/Bar/Home");
+
+            // TODO: posting to /Foo/Home or /Bar/Home with Content-Type: application/x-www-form-urlencoded always routes to the "Bar" feature controller            
+            // return RedirectToAction("Home");
+        }
+    }
+}

--- a/sample/WebApplication/Features/Foo/Home.cshtml
+++ b/sample/WebApplication/Features/Foo/Home.cshtml
@@ -1,0 +1,3 @@
+﻿<div>
+    Main content rendered by FEATURE:Foo:HomeController::Home
+</div>

--- a/sample/WebApplication/Features/Foo/HomeController.cs
+++ b/sample/WebApplication/Features/Foo/HomeController.cs
@@ -1,0 +1,25 @@
+﻿using Microsoft.AspNetCore.Mvc;
+
+namespace WebApplication.Features.Foo
+{
+    [Route("Foo/[controller]")]
+    public class HomeController : Controller
+    {
+        public IActionResult Home()
+        {
+            return View();
+        }
+
+        [HttpPost]
+        public IActionResult Search()
+        {
+            // do some stuff...
+            return View("Home");            
+            // this will also work
+            // return Redirect("/Foo/Home");
+
+            // TODO: posting to /Foo/Home or /Bar/Home with Content-Type: application/x-www-form-urlencoded always routes to the "Bar" feature controller            
+            // return RedirectToAction("Home");
+        }
+    }
+}

--- a/sample/WebApplication/Features/Shared/_Layout.cshtml
+++ b/sample/WebApplication/Features/Shared/_Layout.cshtml
@@ -8,6 +8,11 @@
 <body>
     @await Component.InvokeAsync("MainMenu")
     @RenderBody()
-    <footer>Footer rendered by _Layout</footer>
+    <footer>
+        Footer rendered by _Layout<br />
+        <a href="/">Home</a><br/>
+        <a href="/Foo/Home">Feature: Foo</a><br/>
+        <a href="/Bar/Home">Feature: Bar</a>
+    </footer>
 </body>
 </html>

--- a/src/OdeToCode.AddFeatureFolders/FeatureViewLocationExpander.cs
+++ b/src/OdeToCode.AddFeatureFolders/FeatureViewLocationExpander.cs
@@ -16,7 +16,8 @@ namespace OdeToCode.AddFeatureFolders
 
         public void PopulateValues(ViewLocationExpanderContext context)
         {
-
+            // see: https://stackoverflow.com/questions/36802661/what-is-iviewlocationexpander-populatevalues-for-in-asp-net-core-mvc
+            context.Values["action_displayname"] = context.ActionContext.ActionDescriptor.DisplayName;
         }
 
         public IEnumerable<string> ExpandViewLocations(


### PR DESCRIPTION
There is a caching issue when .cshtml files with the same name exist in multiple features subfolders (e.g. feature "Foo" has a home.cshtml and feature "Bar" has a home.cshtml): sometimes the wrong .cshtml is chosen.

Based on [this stackoverflow article](https://stackoverflow.com/questions/36802661/what-is-iviewlocationexpander-populatevalues-for-in-asp-net-core-mvc) I have modified the PopulateValues method of the FeatureViewLocationExpander so that ExpandViewLocations is not called only once per original filename anymore.

- If you explore the sample application the correct Home.cshtml should be chosen for Home, feature Foo and feature Bar. 
- If you remove/comment out the fix `context.Values["action_displayname"] = context.ActionContext.ActionDescriptor.DisplayName;` and try again the correct controller will be called but the wrong home.cshtml (from the Home feature) will be displayed.

There is still an issue when using RedirectToAction (see TODO) but I haven't figured out (yet) what causes this issue.