### PR TITLE
Add DefaultViewLocation to FeatureFolderOptions,

### DIFF
--- a/src/OdeToCode.AddFeatureFolders/FeatureFolderOptions.cs
+++ b/src/OdeToCode.AddFeatureFolders/FeatureFolderOptions.cs
@@ -13,6 +13,7 @@ namespace OdeToCode.AddFeatureFolders
             FeatureFolderName = "Features";
             DeriveFeatureFolderName = null;
             FeatureNamePlaceholder = "{Feature}";
+            DefaultViewLocation = @"\Features\{0}\{1}.cshtml";
         }
 
         /// <summary>
@@ -39,5 +40,12 @@ namespace OdeToCode.AddFeatureFolders
         /// replaces {feature} with the feature path derived from the ControllerModel
         /// </summary>
         public string FeatureNamePlaceholder { get; set; }
+
+        /// <summary>
+        /// The default view location. Helps intellisense find razor views. Example:
+        ///     "\Features\{0}\{1}.cshtml". 
+        /// Razor replaces the controller name into {0} placeholder & view name into the {1} placeholder. 
+        /// </summary>
+        public string DefaultViewLocation { get; set; }
     }
 }

--- a/src/OdeToCode.AddFeatureFolders/ServiceCollectionExtensions.cs
+++ b/src/OdeToCode.AddFeatureFolders/ServiceCollectionExtensions.cs
@@ -29,6 +29,7 @@ namespace Microsoft.Extensions.DependencyInjection
                                          o.ViewLocationFormats.Clear();
                                          o.ViewLocationFormats.Add(options.FeatureNamePlaceholder + @"\{0}.cshtml");
                                          o.ViewLocationFormats.Add(options.FeatureFolderName + @"\Shared\{0}.cshtml");
+                                         o.ViewLocationFormats.Add(options.DefaultViewLocation);
                                          o.ViewLocationExpanders.Add(expander);
                                      });
 


### PR DESCRIPTION
By default VS intellisense can not find razor views within feature folders.
_Razor views can be found during run time, PR simply fixes intellisense_

Adding a DefaultViewLocation property to FeatureFolderOptions, and adding it to ViewLocationFormats removes the intellisense error. 

Before:
![image](https://user-images.githubusercontent.com/1758965/36176363-42f2fc6e-110a-11e8-9c2c-dd3d2ed32263.png)

After:
![image](https://user-images.githubusercontent.com/1758965/36176387-567a63a8-110a-11e8-98c8-c53cae78ecc1.png)
