### PR TITLE
Fix default view location

### DIFF
--- a/src/OdeToCode.AddFeatureFolders/FeatureFolderOptions.cs
+++ b/src/OdeToCode.AddFeatureFolders/FeatureFolderOptions.cs
@@ -13,7 +13,7 @@ namespace OdeToCode.AddFeatureFolders
             FeatureFolderName = "Features";
             DeriveFeatureFolderName = null;
             FeatureNamePlaceholder = "{Feature}";
-            DefaultViewLocation = @"\Features\{0}\{1}.cshtml";
+            DefaultViewLocation = @"\Features\{1}\{0}.cshtml";
         }
 
         /// <summary>


### PR DESCRIPTION
I just tried using your package on a new project I've created.

My Features directory hierarchy is:

```
Features
-- Account
    -- AccountController.cs
    -- Register.cshtml
...
```

I've added feature folders in `Startup.cs` like this:

```
services
  .AddMvc()
  .AddFeatureFolders()
...
```

In the current implementation of this package, when I browse to the `Register` view I get the following error:

```
InvalidOperationException: The view 'Register' was not found. The following locations were searched:
\Register.cshtml
Features\Shared\Register.cshtml
\Features\Register\Account.cshtml
```

In [FeatureFolderOptions.cs](https://github.com/OdeToCode/AddFeatureFolders/blob/master/src/OdeToCode.AddFeatureFolders/FeatureFolderOptions.cs) the `DefaultViewLocation` is defined as:

> DefaultViewLocation = @"\Features\\{0}\\{1}.cshtml";

I think it _should_ be the other way round:

> DefaultViewLocation = @"\Features\\{1}\\{0}.cshtml";

I've made the change in this PR. Apologies if I've misunderstood how to use your library. If that's the case, maybe you could let me know how I should use it?

Nick

