### PR TITLE
Add net6.0 target using framework reference

### DIFF
--- a/src/OdeToCode.AddFeatureFolders/OdeToCode.AddFeatureFolders.csproj
+++ b/src/OdeToCode.AddFeatureFolders/OdeToCode.AddFeatureFolders.csproj
@@ -5,7 +5,7 @@
     <Copyright>OdeToCode LLC</Copyright>
     <VersionPrefix>2.0.3</VersionPrefix>
     <Authors>K. Scott Allen</Authors>
-    <TargetFrameworks>netstandard1.6;netstandard2.0;net452</TargetFrameworks>
+    <TargetFrameworks>netstandard1.6;netstandard2.0;net452;net6.0</TargetFrameworks>
     <AssemblyName>OdeToCode.AddFeatureFolders</AssemblyName>
     <PackageId>OdeToCode.AddFeatureFolders</PackageId>
     <PackageTags>feature folders;asp.net core</PackageTags>
@@ -25,10 +25,17 @@
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="2.0.0" />
   </ItemGroup>
 
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+	  <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="6.0.0" />
+  </ItemGroup>
+  <ItemGroup Condition=" '$(TargetFramework)' == 'net6.0' ">
+	  <FrameworkReference Include="Microsoft.AspNetCore.App" />
+  </ItemGroup>
+
   <ItemGroup Condition=" '$(TargetFramework)' == 'net452' ">
     <PackageReference Include="Microsoft.AspNetCore.Mvc.Razor" Version="1.0.3" />
     <PackageReference Include="Microsoft.Extensions.DependencyInjection.Abstractions" Version="1.0.2" />
-    
+
     <Reference Include="System" />
     <Reference Include="Microsoft.CSharp" />
   </ItemGroup>


### PR DESCRIPTION
`Microsoft.AspNetCore.Mvc.Razor` references `Microsoft.CodeAnalysis.CSharp` which appears to conflict with the .net6.0 built-in analysers, causing multiple CS8032 warning messages.

By targeting net6.0 directly and using a framework reference to include Razor, the analyser reference is removed.